### PR TITLE
ch(setup) Project setup and theming

### DIFF
--- a/lib/core/theme/app_colors.dart
+++ b/lib/core/theme/app_colors.dart
@@ -2,40 +2,23 @@ import 'package:flutter/material.dart';
 
 class AppColors {
   // Primary Colors
-  static const Color primaryNeon = Color(0xFFD2FF00);
-  static const Color darkBackground = Color(0xFF0C0C0C);
-  static const Color cardGray = Color(0xFF2B2B2B);
-  static const Color accentGreen = Color(0xFFC0FF00);
+  static const Color primaryGreen = Color(0xFF4CAF50);
+  static const Color accentGreen = Color(0xFF81C784);
 
-  // Text Colors
-  static const Color textWhite = Color(0xFFFFFFFF);
-  static const Color textLightGray = Color(0xFFCCCCCC);
+  // Backgrounds
+  static const Color background = Color(0xFFFFFFFF);
+  static const Color cardBackground = Color(0xFFF8F8F8);
 
-  // Semantic Colors
-  static const Color success = Color(0xFF4CAF50);
-  static const Color warning = Color(0xFFFF9800);
+  // Text
+  static const Color textPrimary = Color(0xFF212121);
+  static const Color textSecondary = Color(0xFF757575);
+
+  // Borders & Dividers
+  static const Color divider = Color(0xFFE0E0E0);
+
+  // Semantic
   static const Color error = Color(0xFFF44336);
-  static const Color info = Color(0xFF2196F3);
 
-  // Gradient Colors
-  static const LinearGradient primaryGradient = LinearGradient(
-    colors: [primaryNeon, accentGreen],
-    begin: Alignment.topLeft,
-    end: Alignment.bottomRight,
-  );
-
-  static const LinearGradient darkGradient = LinearGradient(
-    colors: [darkBackground, Color(0xFF1A1A1A)],
-    begin: Alignment.topCenter,
-    end: Alignment.bottomCenter,
-  );
-
-  // Shadow Colors
-  static Color primaryShadow = primaryNeon.withValues(alpha: 0.3);
-  static Color accentShadow = accentGreen.withValues(alpha: 0.3);
-  static Color cardShadow = Colors.black.withValues(alpha: 0.2);
-
-  // Disabled Colors
-  static const Color disabled = Color(0xFF666666);
-  static const Color disabledLight = Color(0xFF999999);
+  // Shadow
+  static const Color cardShadow = Colors.black12;
 }

--- a/lib/core/theme/app_text_styles.dart
+++ b/lib/core/theme/app_text_styles.dart
@@ -2,125 +2,127 @@ import 'package:flutter/material.dart';
 import 'app_colors.dart';
 
 class AppTextStyles {
-  // Heading Styles
+  // Headings
   static const TextStyle h1 = TextStyle(
     fontSize: 32,
     fontWeight: FontWeight.bold,
-    color: AppColors.textWhite,
+    color: AppColors.textPrimary,
     height: 1.2,
   );
 
   static const TextStyle h2 = TextStyle(
     fontSize: 28,
     fontWeight: FontWeight.bold,
-    color: AppColors.textWhite,
+    color: AppColors.textPrimary,
     height: 1.3,
   );
 
   static const TextStyle h3 = TextStyle(
     fontSize: 24,
     fontWeight: FontWeight.w600,
-    color: AppColors.textWhite,
+    color: AppColors.textPrimary,
     height: 1.3,
   );
 
   static const TextStyle h4 = TextStyle(
     fontSize: 20,
     fontWeight: FontWeight.w600,
-    color: AppColors.textWhite,
+    color: AppColors.textPrimary,
     height: 1.4,
   );
 
-  // Body Text Styles
+  // Body
   static const TextStyle bodyLarge = TextStyle(
     fontSize: 16,
     fontWeight: FontWeight.normal,
-    color: AppColors.textWhite,
+    color: AppColors.textPrimary,
     height: 1.5,
   );
 
   static const TextStyle bodyMedium = TextStyle(
     fontSize: 14,
     fontWeight: FontWeight.normal,
-    color: AppColors.textWhite,
+    color: AppColors.textPrimary,
     height: 1.5,
   );
 
   static const TextStyle bodySmall = TextStyle(
     fontSize: 12,
     fontWeight: FontWeight.normal,
-    color: AppColors.textWhite,
+    color: AppColors.textPrimary,
     height: 1.4,
   );
 
-  // Special Text Styles
+  // Special
   static const TextStyle subtitle = TextStyle(
     fontSize: 16,
     fontWeight: FontWeight.w500,
-    color: AppColors.textLightGray,
+    color: AppColors.textSecondary,
     height: 1.5,
   );
 
   static const TextStyle caption = TextStyle(
     fontSize: 12,
     fontWeight: FontWeight.normal,
-    color: AppColors.textLightGray,
+    color: AppColors.textSecondary,
     height: 1.4,
   );
 
   static const TextStyle button = TextStyle(
     fontSize: 16,
     fontWeight: FontWeight.w600,
+    color: AppColors.textPrimary,
     height: 1.2,
   );
 
   static const TextStyle buttonLarge = TextStyle(
     fontSize: 18,
     fontWeight: FontWeight.bold,
+    color: AppColors.textPrimary,
     height: 1.2,
   );
 
-  // Onboarding Specific Styles
+  // Onboarding
   static const TextStyle onboardingTitle = TextStyle(
     fontSize: 32,
     fontWeight: FontWeight.w300,
-    color: AppColors.textWhite,
+    color: AppColors.textPrimary,
     height: 1.2,
   );
 
   static const TextStyle onboardingTitleBold = TextStyle(
     fontSize: 32,
     fontWeight: FontWeight.bold,
-    color: AppColors.primaryNeon,
+    color: AppColors.primaryGreen,
     height: 1.2,
   );
 
   static const TextStyle onboardingDescription = TextStyle(
     fontSize: 16,
     fontWeight: FontWeight.normal,
-    color: AppColors.textLightGray,
+    color: AppColors.textSecondary,
     height: 1.5,
   );
 
   static const TextStyle onboardingFeature = TextStyle(
     fontSize: 16,
     fontWeight: FontWeight.normal,
-    color: AppColors.textWhite,
+    color: AppColors.textPrimary,
     height: 1.4,
   );
 
-  // Brand Text Style
+  // Brand
   static const TextStyle brand = TextStyle(
     fontSize: 16,
     fontWeight: FontWeight.bold,
-    color: AppColors.primaryNeon,
+    color: AppColors.primaryGreen,
     letterSpacing: 0.5,
   );
 
-  // Navigation Text Style
+  // Navigation
   static const TextStyle navigation = TextStyle(
     fontSize: 16,
     fontWeight: FontWeight.w500,
-    color: AppColors.textLightGray,
+    color: AppColors.textSecondary,
   );
 }

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,80 +1,78 @@
+import 'package:calorie_tracker_app/core/theme/app_colors.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'app_colors.dart';
-import 'app_text_styles.dart';
 
 class AppTheme {
-  static ThemeData get darkTheme {
+  static ThemeData get lightTheme {
     return ThemeData(
-      brightness: Brightness.dark,
-      primarySwatch: _createMaterialColor(AppColors.primaryNeon),
-      primaryColor: AppColors.primaryNeon,
-      scaffoldBackgroundColor: AppColors.darkBackground,
-      canvasColor: AppColors.darkBackground,
-      cardColor: AppColors.cardGray,
+      brightness: Brightness.light,
+      primarySwatch: Colors.green,
+      primaryColor: AppColors.primaryGreen,
+      scaffoldBackgroundColor: AppColors.background,
+      cardColor: AppColors.cardBackground,
+      canvasColor: AppColors.background,
 
-      // Color Scheme
-      colorScheme: const ColorScheme.dark(
-        primary: AppColors.primaryNeon,
+      colorScheme: const ColorScheme.light(
+        primary: AppColors.primaryGreen,
         secondary: AppColors.accentGreen,
-        surface: AppColors.cardGray,
+        surface: AppColors.cardBackground,
         error: AppColors.error,
-        onPrimary: AppColors.darkBackground,
-        onSecondary: AppColors.darkBackground,
-        onSurface: AppColors.textWhite,
-        onSurfaceVariant: AppColors.textWhite,
-        onError: AppColors.textWhite,
+        onPrimary: Colors.white,
+        onSecondary: Colors.white,
+        onSurface: AppColors.textPrimary,
+        onError: Colors.white,
       ),
 
-      // App Bar Theme
       appBarTheme: const AppBarTheme(
-        backgroundColor: AppColors.darkBackground,
-        foregroundColor: AppColors.textWhite,
+        backgroundColor: AppColors.background,
+        foregroundColor: AppColors.textPrimary,
         elevation: 0,
         centerTitle: true,
-        titleTextStyle: AppTextStyles.h3,
-        systemOverlayStyle: SystemUiOverlayStyle.light,
+        systemOverlayStyle: SystemUiOverlayStyle.dark,
       ),
 
-      // Text Theme
       textTheme: const TextTheme(
-        displayLarge: AppTextStyles.h1,
-        displayMedium: AppTextStyles.h2,
-        displaySmall: AppTextStyles.h3,
-        headlineLarge: AppTextStyles.h1,
-        headlineMedium: AppTextStyles.h2,
-        headlineSmall: AppTextStyles.h3,
-        titleLarge: AppTextStyles.h4,
-        titleMedium: AppTextStyles.bodyLarge,
-        titleSmall: AppTextStyles.bodyMedium,
-        bodyLarge: AppTextStyles.bodyLarge,
-        bodyMedium: AppTextStyles.bodyMedium,
-        bodySmall: AppTextStyles.bodySmall,
-        labelLarge: AppTextStyles.button,
-        labelMedium: AppTextStyles.bodyMedium,
-        labelSmall: AppTextStyles.caption,
+        displayLarge: TextStyle(
+          fontSize: 32,
+          fontWeight: FontWeight.bold,
+          color: AppColors.textPrimary,
+        ),
+        displayMedium: TextStyle(
+          fontSize: 28,
+          fontWeight: FontWeight.bold,
+          color: AppColors.textPrimary,
+        ),
+        displaySmall: TextStyle(
+          fontSize: 24,
+          fontWeight: FontWeight.w600,
+          color: AppColors.textPrimary,
+        ),
+        bodyLarge: TextStyle(fontSize: 16, color: AppColors.textPrimary),
+        bodyMedium: TextStyle(fontSize: 14, color: AppColors.textPrimary),
+        bodySmall: TextStyle(fontSize: 12, color: AppColors.textSecondary),
+        labelLarge: TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.w600,
+          color: AppColors.textPrimary,
+        ),
       ),
 
-      // Elevated Button Theme
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
-          backgroundColor: AppColors.primaryNeon,
-          foregroundColor: AppColors.darkBackground,
-          textStyle: AppTextStyles.button,
+          backgroundColor: AppColors.primaryGreen,
+          foregroundColor: Colors.white,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(28),
           ),
-          elevation: 0,
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+          elevation: 0,
         ),
       ),
 
-      // Outlined Button Theme
       outlinedButtonTheme: OutlinedButtonThemeData(
         style: OutlinedButton.styleFrom(
-          foregroundColor: AppColors.primaryNeon,
-          side: const BorderSide(color: AppColors.primaryNeon, width: 2),
-          textStyle: AppTextStyles.button,
+          foregroundColor: AppColors.primaryGreen,
+          side: const BorderSide(color: AppColors.primaryGreen, width: 2),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(28),
           ),
@@ -82,131 +80,49 @@ class AppTheme {
         ),
       ),
 
-      // Text Button Theme
-      textButtonTheme: TextButtonThemeData(
-        style: TextButton.styleFrom(
-          foregroundColor: AppColors.primaryNeon,
-          textStyle: AppTextStyles.button,
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        ),
-      ),
-
-      // Input Decoration Theme
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: AppColors.cardGray,
+        fillColor: AppColors.cardBackground,
         border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(12),
-          borderSide: BorderSide.none,
-        ),
-        enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
           borderSide: BorderSide.none,
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: AppColors.primaryNeon, width: 2),
+          borderSide: const BorderSide(color: AppColors.primaryGreen, width: 2),
         ),
-        errorBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(12),
-          borderSide: const BorderSide(color: AppColors.error, width: 2),
-        ),
-        hintStyle: AppTextStyles.subtitle,
-        labelStyle: AppTextStyles.bodyMedium,
+        hintStyle: const TextStyle(color: AppColors.textSecondary),
+        labelStyle: const TextStyle(color: AppColors.textSecondary),
         contentPadding: const EdgeInsets.all(16),
       ),
 
-      // Card Theme
+      iconTheme: const IconThemeData(color: AppColors.textPrimary, size: 24),
+
+      dividerTheme: const DividerThemeData(
+        color: AppColors.divider,
+        thickness: 1,
+      ),
+
       cardTheme: CardThemeData(
-        color: AppColors.cardGray,
-        elevation: 8,
+        color: AppColors.cardBackground,
+        elevation: 2,
         shadowColor: AppColors.cardShadow,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       ),
 
-      // Icon Theme
-      iconTheme: const IconThemeData(color: AppColors.textWhite, size: 24),
-
-      // Progress Indicator Theme
-      progressIndicatorTheme: const ProgressIndicatorThemeData(
-        color: AppColors.primaryNeon,
-        linearTrackColor: AppColors.cardGray,
-        circularTrackColor: AppColors.cardGray,
+      floatingActionButtonTheme: const FloatingActionButtonThemeData(
+        backgroundColor: AppColors.primaryGreen,
+        foregroundColor: Colors.white,
+        elevation: 4,
       ),
 
-      // Divider Theme
-      dividerTheme: const DividerThemeData(
-        color: AppColors.cardGray,
-        thickness: 1,
-        space: 1,
-      ),
-
-      // Bottom Navigation Bar Theme
       bottomNavigationBarTheme: const BottomNavigationBarThemeData(
-        backgroundColor: AppColors.cardGray,
-        selectedItemColor: AppColors.primaryNeon,
-        unselectedItemColor: AppColors.textLightGray,
+        backgroundColor: AppColors.background,
+        selectedItemColor: AppColors.primaryGreen,
+        unselectedItemColor: AppColors.textSecondary,
         type: BottomNavigationBarType.fixed,
         elevation: 8,
       ),
-
-      // Floating Action Button Theme
-      floatingActionButtonTheme: const FloatingActionButtonThemeData(
-        backgroundColor: AppColors.primaryNeon,
-        foregroundColor: AppColors.darkBackground,
-        elevation: 8,
-      ),
-
-      // Chip Theme
-      chipTheme: ChipThemeData(
-        backgroundColor: AppColors.cardGray,
-        labelStyle: AppTextStyles.bodyMedium,
-        secondaryLabelStyle: AppTextStyles.bodyMedium,
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-      ),
-
-      // Dialog Theme
-      dialogTheme: DialogThemeData(
-        backgroundColor: AppColors.cardGray,
-        titleTextStyle: AppTextStyles.h3,
-        contentTextStyle: AppTextStyles.bodyMedium,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      ),
-
-      // Snack Bar Theme
-      snackBarTheme: SnackBarThemeData(
-        backgroundColor: AppColors.cardGray,
-        contentTextStyle: AppTextStyles.bodyMedium,
-        actionTextColor: AppColors.primaryNeon,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-      ),
     );
-  }
-
-  // Helper method to create MaterialColor from Color
-  static MaterialColor _createMaterialColor(Color color) {
-    List strengths = <double>[.05];
-    Map<int, Color> swatch = {};
-    final int r = (color.r * 255.0).round() & 0xff;
-    final int g = (color.g * 255.0).round() & 0xff;
-    final int b = (color.b * 255.0).round() & 0xff;
-
-
-    for (int i = 1; i < 10; i++) {
-      strengths.add(0.1 * i);
-    }
-
-    for (double strength in strengths) {
-      final double ds = 0.5 - strength;
-      swatch[(strength * 1000).round()] = Color.fromRGBO(
-        r + ((ds < 0 ? r : (255 - r)) * ds).round(),
-        g + ((ds < 0 ? g : (255 - g)) * ds).round(),
-        b + ((ds < 0 ? b : (255 - b)) * ds).round(),
-        1,
-      );
-    }
-
-    return MaterialColor(color.value, swatch);
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,7 +14,7 @@ class FitTrackApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Fitness Tracker',
-      theme: AppTheme.darkTheme,
+      theme: AppTheme.lightTheme,
       home: const TabsScreen(),
       debugShowCheckedModeBanner: false,
     );

--- a/lib/ui/dashboard/view/dashboard_screen.dart
+++ b/lib/ui/dashboard/view/dashboard_screen.dart
@@ -34,9 +34,9 @@ class DashboardScreen extends ConsumerWidget {
           ],
         ),
         actions: const [
-          Icon(Icons.emoji_events, color: AppColors.primaryNeon),
+          Icon(Icons.emoji_events, color: AppColors.primaryGreen),
           SizedBox(width: AppDimensions.spaceS),
-          Icon(Icons.notifications, color: AppColors.primaryNeon),
+          Icon(Icons.notifications, color: AppColors.primaryGreen),
           SizedBox(width: AppDimensions.spaceM),
         ],
       ),

--- a/lib/ui/dashboard/widget/program_card.dart
+++ b/lib/ui/dashboard/widget/program_card.dart
@@ -14,7 +14,7 @@ class ProgramCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: AppColors.cardGray,
+        color: AppColors.cardBackground,
         borderRadius: BorderRadius.circular(AppDimensions.radiusL),
       ),
       child: Row(
@@ -37,8 +37,8 @@ class ProgramCard extends StatelessWidget {
                 const SizedBox(height: AppDimensions.spaceS),
                 LinearProgressIndicator(
                   value: progress,
-                  color: AppColors.primaryNeon,
-                  backgroundColor: AppColors.darkBackground,
+                  color: AppColors.primaryGreen,
+                  backgroundColor: AppColors.background,
                 ),
               ],
             ),

--- a/lib/ui/dashboard/widget/program_icon.dart
+++ b/lib/ui/dashboard/widget/program_icon.dart
@@ -15,14 +15,14 @@ class ProgramIcon extends StatelessWidget {
       margin: const EdgeInsets.only(right: AppDimensions.spaceM),
       padding: const EdgeInsets.all(AppDimensions.paddingM),
       decoration: BoxDecoration(
-        color: AppColors.cardGray,
+        color: AppColors.cardBackground,
         borderRadius: BorderRadius.circular(AppDimensions.radiusL),
       ),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
 
         children: [
-          Icon(icon, color: AppColors.primaryNeon),
+          Icon(icon, color: AppColors.primaryGreen),
           const SizedBox(height: AppDimensions.spaceS),
           Text(label, style: AppTextStyles.bodySmall),
         ],

--- a/lib/ui/dashboard/widget/stats_row.dart
+++ b/lib/ui/dashboard/widget/stats_row.dart
@@ -16,7 +16,7 @@ class StatsRow extends StatelessWidget {
           child: Container(
             padding: const EdgeInsets.all(AppDimensions.paddingM),
             decoration: BoxDecoration(
-              color: AppColors.primaryNeon,
+              color: AppColors.primaryGreen,
               borderRadius: BorderRadius.circular(AppDimensions.radiusL),
             ),
             child: Column(
@@ -24,7 +24,7 @@ class StatsRow extends StatelessWidget {
               children: [
                 Text(
                   'Calories',
-                  style: AppTextStyles.h4.copyWith(color: AppColors.darkBackground),
+                  style: AppTextStyles.h4.copyWith(color: AppColors.background),
                 ),
 
                 const SizedBox(height: AppDimensions.spaceM),
@@ -37,8 +37,8 @@ class StatsRow extends StatelessWidget {
                         width: 120,
                         child: CircularProgressIndicator(
                           value: 0.73,
-                          color: AppColors.darkBackground,
-                          backgroundColor: AppColors.textWhite,
+                          color: AppColors.background,
+                          backgroundColor: AppColors.textPrimary,
                           strokeWidth: 10,
                         ),
                       ),
@@ -48,14 +48,14 @@ class StatsRow extends StatelessWidget {
                           Text(
                             '730',
                             style: AppTextStyles.h3.copyWith(
-                              color: AppColors.darkBackground,
+                              color: AppColors.background,
                             ),
                           ),
                           const SizedBox(height: AppDimensions.spaceXS),
                           Text(
                             '/kCal',
                             style: AppTextStyles.bodySmall.copyWith(
-                              color: AppColors.darkBackground,
+                              color: AppColors.background,
                             ),
                           ),
                         ],
@@ -74,12 +74,12 @@ class StatsRow extends StatelessWidget {
               Container(
                 padding: const EdgeInsets.all(AppDimensions.paddingM),
                 decoration: BoxDecoration(
-                  color: AppColors.cardGray,
+                  color: AppColors.cardBackground,
                   borderRadius: BorderRadius.circular(AppDimensions.radiusL),
                 ),
                 child: Column(
                   children: const [
-                    Icon(Icons.directions_walk, color: AppColors.primaryNeon),
+                    Icon(Icons.directions_walk, color: AppColors.primaryGreen),
                     SizedBox(height: AppDimensions.spaceS),
                     Text('Steps', style: AppTextStyles.subtitle),
                     Text('230', style: AppTextStyles.h4),
@@ -90,7 +90,7 @@ class StatsRow extends StatelessWidget {
               Container(
                 padding: const EdgeInsets.all(AppDimensions.paddingM),
                 decoration: BoxDecoration(
-                  color: AppColors.cardGray,
+                  color: AppColors.cardBackground,
                   borderRadius: BorderRadius.circular(AppDimensions.radiusL),
                 ),
                 child: Column(
@@ -103,8 +103,8 @@ class StatsRow extends StatelessWidget {
                         children: [
                           CircularProgressIndicator(
                             value: 5 / 8,
-                            color: AppColors.primaryNeon,
-                            backgroundColor: AppColors.darkBackground,
+                            color: AppColors.primaryGreen,
+                            backgroundColor: AppColors.background,
                             strokeWidth: 5,
                           ),
                           const Text(''),

--- a/lib/ui/dashboard/widget/work_progress.dart
+++ b/lib/ui/dashboard/widget/work_progress.dart
@@ -11,7 +11,7 @@ class WorkProgress extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(AppDimensions.paddingM),
       decoration: BoxDecoration(
-        color: AppColors.cardGray,
+        color: AppColors.cardBackground,
         borderRadius: BorderRadius.circular(AppDimensions.radiusL),
       ),
       child: Row(
@@ -33,8 +33,8 @@ class WorkProgress extends StatelessWidget {
                 width: 50,
                 child: CircularProgressIndicator(
                   value: 0.75,
-                  color: AppColors.primaryNeon,
-                  backgroundColor: AppColors.cardGray,
+                  color: AppColors.primaryGreen,
+                  backgroundColor: AppColors.cardBackground,
                   strokeWidth: 5,
                 ),
               ),
@@ -45,4 +45,4 @@ class WorkProgress extends StatelessWidget {
       ),
     );
   }
-  }
+}

--- a/lib/ui/tabs/view/tabs_screen.dart
+++ b/lib/ui/tabs/view/tabs_screen.dart
@@ -14,9 +14,7 @@ class TabsScreen extends ConsumerStatefulWidget {
 class _TabsScreenState extends ConsumerState<TabsScreen> {
   int _selectedIndex = 0;
 
-  final List<Widget> _screens = [
-   DashboardScreen()
-  ];
+  final List<Widget> _screens = [DashboardScreen()];
 
   void _onTappedItem(int index) {
     setState(() {
@@ -31,9 +29,9 @@ class _TabsScreenState extends ConsumerState<TabsScreen> {
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _selectedIndex,
         onTap: _onTappedItem,
-        backgroundColor: AppColors.cardGray,
-        selectedItemColor: AppColors.primaryNeon,
-        unselectedItemColor: AppColors.textLightGray,
+        backgroundColor: AppColors.cardBackground,
+        selectedItemColor: AppColors.primaryGreen,
+        unselectedItemColor: AppColors.textSecondary,
         type: BottomNavigationBarType.fixed,
         elevation: AppDimensions.bottomNavElevation,
         items: const [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -148,7 +148,7 @@ packages:
     source: hosted
     version: "1.16.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   sqflite: ^2.4.2
   path_provider: ^2.1.5
   flutter_riverpod: ^2.6.1
+  path: ^1.9.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
---

# `ch(setup) Project setup and theming`

---

#### What does this PR do?

Sets up the project with a **standard clean architecture** and establishes the **application colors and theme** consistent with the provided app designs.

---

#### Description of Task to be completed?

* Organized the folder structure using clean architecture conventions:

  * `core`, `features`, `shared`
  * Inside each: `presentation`, `domain`, `data` layers
* Defined global color system (`AppColors`) for a light mode theme based on brand specifications.
* Created consistent `AppTextStyles` for typography across headings, body, and captions.
* Implemented `AppTheme` for light mode, covering app bars, buttons, text fields, and cards.
* Prepared foundation for easy scalability (future dark mode toggle ready but only light mode active now).

---

#### How should this be manually tested?

* Run the app on an emulator or physical device.
* Confirm:

  * The app displays the correct light theme colors across all screens.
  * Typography and buttons use the specified styles.
  * There are no console errors for missing theme values.

---

#### Any background context you want to provide?

* This is an initial **setup chore** to align the app visually with the intended brand direction (light, green-accented health UI).
* The clean architecture structure ensures future scalability, easier testing, and clear separation of concerns.

---

#### Questions:

* Would you like to include automated lint checks or formatters (like `flutter_lints` or `very_good_analysis`) in this setup?
* Should we prepare a `ThemeProvider` or `ThemeCubit` even though dark mode is not yet planned?

---

### ✅ PR Etiquette Checklist

* [x] Assigned a developer & TTL as reviewers
* [x] Notified reviewers on Slack
* [x] Will respect 8-hour SLA before merging if unreviewed
* [x] All CI checks will pass before merging
* [x] Will take responsibility for fixing any issues after merging

---